### PR TITLE
Improve project's structure

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  endOfLine: "lf",
+  endOfLine: "auto",
   semi: false,
   singleQuote: false,
   tabWidth: 2,

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -2,17 +2,17 @@ import React, { FC, useState, useRef, useEffect, useContext } from "react"
 import { useRouter } from "next/router"
 
 // Global state management
-import { ThemeContext } from "../context/ThemeContext"
+import { ThemeContext } from "@/context/ThemeContext"
 
 // Components
 import Animation from "./Animation"
 
 // Validators
-import { isEmpty, isEmail } from "../utilities/formValidator"
+import { isEmpty, isEmail } from "@/utilities/formValidator"
 import ReCAPTCHA from "react-google-recaptcha"
 
-// Norifications
-import { notify } from "../utilities/notification"
+// Notifications
+import { notify } from "@/utilities/notification"
 
 import axios from "axios" // API fetcher
 

--- a/src/components/ContextTree.tsx
+++ b/src/components/ContextTree.tsx
@@ -1,0 +1,24 @@
+// Global state
+/* import { AuthProvider } from "@/context/UserContext"; */
+import { ThemeProvider } from "@/context/ThemeContext"
+import store from "@/redux/store"
+import React, { ReactNode } from "react"
+import { Provider } from "react-redux"
+import { ToastContainer } from "react-toastify"
+
+interface PropsType {
+  children: ReactNode
+}
+
+const ContextTree = ({ children }: PropsType) => {
+  return (
+    <Provider store={store}>
+      <ThemeProvider>
+        <ToastContainer />
+        {children}
+      </ThemeProvider>
+    </Provider>
+  )
+}
+
+export default ContextTree

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,7 +7,7 @@ import { AttentionSeeker } from "react-awesome-reveal" // Reveal effect
 import links from "./links"
 
 // Global state management
-import { ThemeContext } from "../../context/ThemeContext"
+import { ThemeContext } from "@/context/ThemeContext"
 
 // Translation
 import useTranslation from "next-translate/useTranslation"

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,8 @@
 import React, { FC, useContext } from "react"
 import { useRouter } from "next/router"
 
+import colors from "@/styles/abstracts/_colors.module.scss"
+
 import { AttentionSeeker } from "react-awesome-reveal" // Reveal effect
 
 // Components
@@ -25,12 +27,12 @@ const Footer: FC<IFooter> = ({ color }) => {
     <>
       <svg
         className="footer-separator-svg"
-        style={{ backgroundColor: !darkMode ? color : "#1b1a1a" }}
+        style={{ backgroundColor: !darkMode ? color : colors.secondaryBlack }}
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 1440 320"
       >
         <path
-          fill="#1a1423"
+          fill={colors.primaryBlack}
           fillOpacity="1"
           d="M0,64L720,160L1440,64L1440,320L720,320L0,320Z"
         ></path>

--- a/src/components/Header/ThemeToggler.tsx
+++ b/src/components/Header/ThemeToggler.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useContext } from "react"
-import { ThemeContext } from "../../context/ThemeContext"
+import { ThemeContext } from "@/context/ThemeContext"
 import useTranslation from "next-translate/useTranslation"
 
 const ThemeToggler: FC = () => {

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,19 +1,15 @@
 import React, { FC } from "react"
 import Footer from "@/components/Footer/Footer"
 
-// Global state
-import { Provider } from "react-redux"
-import store from "@/redux/store"
-import { AuthProvider } from "@/context/UserContext"
+// Global state management
+import ContextTree from "../ContextTree"
 
 const Layout: FC = ({ children }) => {
   return (
-    <Provider store={store}>
-      <AuthProvider>
-        <main>{children}</main>
-        <Footer color="#fff" />
-      </AuthProvider>
-    </Provider>
+    <ContextTree>
+      <main>{children}</main>
+      <Footer color="white" />
+    </ContextTree>
   )
 }
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from "react"
-import Footer from "../Footer/Footer"
+import Footer from "@/components/Footer/Footer"
 
 // Global state
 import { Provider } from "react-redux"
-import store from "../../redux/store"
-import { AuthProvider } from "../../context/UserContext"
+import store from "@/redux/store"
+import { AuthProvider } from "@/context/UserContext"
 
 const Layout: FC = ({ children }) => {
   return (

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react"
 import ProjectCard from "./ProjectCard"
-import projects from "../data/projects.json"
+import projects from "@/data/projects.json"
 
 // Translation
 import useTranslation from "next-translate/useTranslation"

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react"
 import SkillCard from "./SkillCard"
-import skills from "../data/skills.json"
+import skills from "@/data/skills.json"
 
 // Translation
 import useTranslation from "next-translate/useTranslation"

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -11,6 +11,7 @@ import NotFoundImage from "@/resources/NotFoundImage"
 import useTranslation from "next-translate/useTranslation"
 import Trans from "next-translate/Trans"
 
+// In seconds
 const TIMER_COUNT = 3
 
 const PageNotFound: NextPage = () => {
@@ -67,5 +68,8 @@ const PageNotFound: NextPage = () => {
     </>
   )
 }
+
+// To avoid build's minified name not matching development's Component.name
+PageNotFound.displayName = "PageNotFound"
 
 export default PageNotFound

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -5,7 +5,7 @@ import { NextRouter, useRouter } from "next/router"
 import Head from "next/head"
 
 // Svg
-import NotFoundImage from "../resources/NotFoundImage"
+import NotFoundImage from "@/resources/NotFoundImage"
 
 // Translation
 import useTranslation from "next-translate/useTranslation"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 // Styles
 import "react-toastify/dist/ReactToastify.css"
-import "../styles/app.scss"
+import "@/styles/app.scss"
 
 // React & Next hooks
 import React, { useEffect } from "react"
@@ -9,17 +9,17 @@ import { useRouter } from "next/router"
 
 // Global state
 import { Provider } from "react-redux"
-import store from "../redux/store"
-/* import { AuthProvider } from "../context/UserContext"; */
-import { ThemeProvider } from "../context/ThemeContext"
+import store from "@/redux/store"
+/* import { AuthProvider } from "@/context/UserContext"; */
+import { ThemeProvider } from "@/context/ThemeContext"
 
-import * as gtag from "../lib/gtag" // Google Analytics
+import * as gtag from "@/lib/gtag" // Google Analytics
 
 // Components
 import { ToastContainer } from "react-toastify"
-import Layout from "../components/Layout/Layout"
-import Footer from "../components/Footer/Footer"
-import { isProduction } from "../utilities/general"
+import Layout from "@/components/Layout/Layout"
+import Footer from "@/components/Footer/Footer"
+import { isProduction } from "@/utilities/general"
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -29,7 +29,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, [router.events])
 
   // Applying different layouts depending on page
-  switch (Component.name) {
+  switch (Component.displayName) {
     case "HomePage":
       return (
         <ContextTree>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,19 +7,12 @@ import React, { useEffect } from "react"
 import type { AppProps } from "next/app"
 import { useRouter } from "next/router"
 
-// Global state
-import { Provider } from "react-redux"
-import store from "@/redux/store"
-/* import { AuthProvider } from "@/context/UserContext"; */
-import { ThemeProvider } from "@/context/ThemeContext"
-
 import * as gtag from "@/lib/gtag" // Google Analytics
 
-// Components
-import { ToastContainer } from "react-toastify"
 import Layout from "@/components/Layout/Layout"
 import Footer from "@/components/Footer/Footer"
 import { isProduction } from "@/utilities/general"
+import ContextTree from "@/components/ContextTree"
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
@@ -39,32 +32,19 @@ function MyApp({ Component, pageProps }: AppProps) {
   switch (Component.name) {
     case "HomePage":
       return (
-        <Provider store={store}>
-          <ThemeProvider>
-            <ToastContainer />
-            <Component {...pageProps} />
-            <Footer color="fff" />
-          </ThemeProvider>
-        </Provider>
+        <ContextTree>
+          <Component {...pageProps} />
+          <Footer color="white" />
+        </ContextTree>
       )
     case "PageNotFound":
-      return (
-        <>
-          <Component {...pageProps} />
-          <Footer color="#f2f2f5" />
-        </>
-      )
+      return <Component {...pageProps} />
 
     default:
       return (
-        <Provider store={store}>
-          <ThemeProvider>
-            <Layout>
-              <ToastContainer />
-              <Component {...pageProps} />
-            </Layout>
-          </ThemeProvider>
-        </Provider>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
       )
   }
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,8 +8,8 @@ import Document, {
   DocumentContext,
 } from "next/document"
 
-import { isProduction } from "../utilities/general"
-import GAnalytics from "../lib/GAnalytics"
+import { isProduction } from "@/utilities/general"
+import GAnalytics from "@/lib/GAnalytics"
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {

--- a/src/pages/api/mail.ts
+++ b/src/pages/api/mail.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 
-import { isEmpty, isEmail, validateHuman } from "../../utilities/formValidator" // Validators
-import { sendEmail, acknowledgeReceipt } from "../../utilities/sendGrid"
-import { APIResponse } from "../../types/api"
-import { isProduction } from "../../utilities/general"
+import { isEmpty, isEmail, validateHuman } from "@/utilities/formValidator" // Validators
+import { sendEmail, acknowledgeReceipt } from "@/utilities/sendGrid"
+import { APIResponse } from "@/types/api"
+import { isProduction } from "@/utilities/general"
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,20 +4,20 @@ import type { NextPage } from "next"
 import Head from "next/head" // For better SEO
 
 // Components
-import About from "../components/About"
-import Projects from "../components/Projects"
-import Skills from "../components/Skills"
-import Contact from "../components/Contact"
-import Header from "../components/Header/Header"
-import Nav from "../components/Header/Nav"
+import About from "@/components/About"
+import Projects from "@/components/Projects"
+import Skills from "@/components/Skills"
+import Contact from "@/components/Contact"
+import Header from "@/components/Header/Header"
+import Nav from "@/components/Header/Nav"
 
 import cn from "classnames"
 
 // Theme
-import { ThemeContext } from "../context/ThemeContext"
+import { ThemeContext } from "@/context/ThemeContext"
 
 // SVG
-import SeparatorSVG from "../svgs/SeparatorSVG" // Wave separating sections
+import SeparatorSVG from "@/svgs/SeparatorSVG" // Wave separating sections
 
 import useTranslation from "next-translate/useTranslation" // Translation
 import { useContext } from "react"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -89,4 +89,6 @@ const HomePage: NextPage = () => {
   )
 }
 
+HomePage.displayName = "HomePage"
+
 export default HomePage

--- a/src/styles/abstracts/_colors.module.scss
+++ b/src/styles/abstracts/_colors.module.scss
@@ -29,3 +29,12 @@ $black-linear-gradient: linear-gradient(315deg, #000000 0%, #414141 74%);
 // Text
 
 // Buttons
+
+// Enables use of Sass variables in JS
+
+:export {
+  primaryGray: $primary-gray;
+  secondaryGray: $secondary-gray;
+  primaryBlack: $primary-black;
+  secondaryBlack: $secondary-black;
+}

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -2,7 +2,7 @@
 
 /*--- Imports ---*/
 
-@import "abstracts/variables", "abstracts/colors", "abstracts/functions",
+@import "abstracts/variables", "abstracts/colors.module", "abstracts/functions",
   "abstracts/mixins";
 
 @import "base/typography", "base/reset", "base/animations", "base/svg";

--- a/src/svgs/SeparatorSVG.tsx
+++ b/src/svgs/SeparatorSVG.tsx
@@ -1,5 +1,7 @@
 import React, { SVGProps } from "react"
 
+import colors from "@/styles/abstracts/_colors.module.scss"
+
 interface PropTypes extends SVGProps<SVGSVGElement> {
   darkMode: boolean
   direction?: "down" | "up"
@@ -10,13 +12,13 @@ const SeparatorSVG = ({ direction, darkMode, ...rest }: PropTypes) => {
     <svg
       xmlns="http://www.w3.org/2000/svg"
       style={{
-        backgroundColor: !darkMode ? "" : "#1b1a1a",
+        backgroundColor: !darkMode ? "" : colors.secondaryBlack,
       }}
       viewBox="0 0 1440 320"
       {...rest}
     >
       <path
-        fill={!darkMode ? "#f2f2f5" : "#1a1423"}
+        fill={!darkMode ? colors.primaryGray : colors.primaryBlack}
         fillOpacity="1"
         d={
           direction === "down"

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -1,5 +1,5 @@
 // To overwrite default any type to more secure typing
-declare module "../svgs/*.svg" {
+declare module "@/svgs/*.svg" {
   import React from "react"
 
   const Component: React.FunctionComponent<React.SVGProps<SVGSVGElement>>

--- a/src/utilities/notification.ts
+++ b/src/utilities/notification.ts
@@ -1,5 +1,5 @@
 import { toast } from "react-toastify"
-import { APIStatus } from "../types/api"
+import { APIStatus } from "@/types/api"
 
 toast.configure()
 

--- a/src/utilities/sendGrid.ts
+++ b/src/utilities/sendGrid.ts
@@ -1,4 +1,4 @@
-import { Locale } from "../types/locales"
+import { Locale } from "@/types/locales"
 
 const sendgrid = require("@sendgrid/mail")
 sendgrid.setApiKey(process.env.SENDGRID_API_KEY)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- [x] Refactor context into tree component;
- [x] Replace hard-coded hex colours with exported Sass variables;
- [x] Shorten project's paths using `@/` prefix (instead of `../../../../`;
- [x] Replace `Component.name` with `Component.displayName` to prevent unexpected behaviour due to build-induced minified names;
- [x] Set Prettier's ` endOfLine` to `auto` to eliminate the need to run `npx prettier --write .` on every push (due to git hook pre-push checks).