### PR TITLE
9 - Reduce filtering complexity & localise everything

### DIFF
--- a/src/components/Projects/Projects.tsx
+++ b/src/components/Projects/Projects.tsx
@@ -8,9 +8,6 @@ import SectionHeader from "../UI/SectionHeader"
 import { useContext } from "react"
 import { ThemeContext } from "@/context/ThemeContext"
 import cn from "classnames"
-import { useRouter } from "next/router"
-import { getProjectNameByLocale } from "@/graphql/projects"
-import { Locale } from "@/types/locales"
 
 interface PropTypes {
   data: Project[]
@@ -18,7 +15,6 @@ interface PropTypes {
 
 const Projects = ({ data }: PropTypes) => {
   const { t } = useTranslation("common")
-  const { locale } = useRouter()
   const { darkTheme } = useContext(ThemeContext)
 
   return (
@@ -49,7 +45,7 @@ const Projects = ({ data }: PropTypes) => {
         {data.map((project: Project, id: number) => (
           <Card
             key={id}
-            name={getProjectNameByLocale(project, locale as Locale)}
+            name={project.name}
             img={project.image}
             url={project.url}
             repo={project.repo}

--- a/src/graphql/projects.ts
+++ b/src/graphql/projects.ts
@@ -1,12 +1,8 @@
 import { Locale } from "@/types/locales"
-import {
-  Project,
-  LocalisedNames,
-  LocalisedDescription,
-} from "@/types/models/projects"
+import { Project, LocalisedDescription } from "@/types/models/projects"
 
-export const GET_ALL_PROJECTS_QUERY = `query GetAllProjects {
-  allProjects(orderBy: [createdAt_ASC]) {
+export const GET_ALL_PROJECTS_QUERY = `query GetAllProjects($locale: SiteLocale) {
+  allProjects(orderBy: [createdAt_ASC], locale: $locale) {
     name
     _allNameLocales {
       locale
@@ -47,8 +43,8 @@ export const GET_ALL_SLUGS_QUERY = `query GetAllSlugs {
   }
 }`
 
-export const GET_PROJECT_BY_SLUG_QUERY = `query GetProjectBySlug($slug: String!) {
-  project(filter: {slug: {eq: $slug}}) {
+export const GET_PROJECT_BY_SLUG_QUERY = `query GetProjectBySlug($slug: String!, $locale: SiteLocale) {
+  project(filter: {slug: {eq: $slug}}, locale: $locale) {
     name
     _allNameLocales {
       locale
@@ -85,11 +81,6 @@ export const GET_PROJECT_BY_SLUG_QUERY = `query GetProjectBySlug($slug: String!)
     }
   }
 }`
-
-// Return project's name in provided locale
-export const getProjectNameByLocale = (project: Project, locale: Locale) =>
-  project._allNameLocales.find((p: LocalisedNames) => p.locale === locale)
-    ?.value ?? project.name
 
 // Return project's description in provided locale
 export const getProjectDescriptionByLocale = (

--- a/src/graphql/projects.ts
+++ b/src/graphql/projects.ts
@@ -1,6 +1,3 @@
-import { Locale } from "@/types/locales"
-import { Project, LocalisedDescription } from "@/types/models/projects"
-
 export const GET_ALL_PROJECTS_QUERY = `query GetAllProjects($locale: SiteLocale) {
   allProjects(orderBy: [createdAt_ASC], locale: $locale) {
     name
@@ -34,12 +31,6 @@ export const GET_ALL_PROJECTS_QUERY = `query GetAllProjects($locale: SiteLocale)
     url
     slug
     repo
-  }
-}`
-
-export const GET_ALL_SLUGS_QUERY = `query GetAllSlugs {
-  allProjects {
-    slug
   }
 }`
 
@@ -81,12 +72,3 @@ export const GET_PROJECT_BY_SLUG_QUERY = `query GetProjectBySlug($slug: String!,
     }
   }
 }`
-
-// Return project's description in provided locale
-export const getProjectDescriptionByLocale = (
-  project: Project,
-  locale: Locale
-) =>
-  project._allDescriptionLocales.find(
-    (p: LocalisedDescription) => p.locale === locale
-  )?.value.value ?? project.description

--- a/src/pages/api/sitemap.ts
+++ b/src/pages/api/sitemap.ts
@@ -1,4 +1,4 @@
-import { GET_ALL_SLUGS_QUERY } from "@/graphql/projects"
+import { GET_ALL_PROJECTS_QUERY } from "@/graphql/projects"
 import { gqlRequest } from "@/lib/datoCMS"
 import { locales } from "@/utilities/locales"
 import { NextApiRequest, NextApiResponse } from "next"
@@ -18,12 +18,12 @@ const Sitemap = async (req: NextApiRequest, res: NextApiResponse) => {
   })
 
   // Paths with dynamic urls
-  const PROJECT_SLUGS = await gqlRequest({
-    query: GET_ALL_SLUGS_QUERY,
+  const allProjects = await gqlRequest({
+    query: GET_ALL_PROJECTS_QUERY,
   })
 
   // Project urls with dynamic slugs
-  const dynamicLinks = PROJECT_SLUGS.allProjects.map(
+  const dynamicLinks = allProjects.allProjects.map(
     (project: { slug: string }) => {
       return locales.map(locale => ({
         lang: locale,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { NextPage } from "next"
+import type { GetStaticProps, NextPage } from "next"
 import About from "@/components/About"
 import Projects from "@/components/Projects/Projects"
 import Skills from "@/components/Skills/Skills"
@@ -15,6 +15,7 @@ import Hero from "@/components/Hero/Hero"
 import { GET_ALL_PROJECTS_QUERY } from "@/graphql/projects"
 import { gqlRequest } from "@/lib/datoCMS"
 import { Project } from "@/types/models/projects"
+import { Locale } from "@/types/locales"
 
 interface PropTypes {
   data: { allProjects: Project[] }
@@ -72,9 +73,10 @@ const HomePage: NextPage<PropTypes> = ({ data }: PropTypes) => {
   )
 }
 
-export const getStaticProps = async () => {
+export const getStaticProps = async ({ locale }: { locale: Locale }) => {
   const data = await gqlRequest({
     query: GET_ALL_PROJECTS_QUERY,
+    variables: { locale },
   })
   return {
     props: { data },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { GetStaticProps, NextPage } from "next"
+import type { NextPage } from "next"
 import About from "@/components/About"
 import Projects from "@/components/Projects/Projects"
 import Skills from "@/components/Skills/Skills"
@@ -19,6 +19,10 @@ import { Locale } from "@/types/locales"
 
 interface PropTypes {
   data: { allProjects: Project[] }
+}
+
+interface StaticPropTypes {
+  locale: Locale
 }
 
 const HomePage: NextPage<PropTypes> = ({ data }: PropTypes) => {
@@ -73,7 +77,7 @@ const HomePage: NextPage<PropTypes> = ({ data }: PropTypes) => {
   )
 }
 
-export const getStaticProps = async ({ locale }: { locale: Locale }) => {
+export const getStaticProps = async ({ locale }: StaticPropTypes) => {
   const data = await gqlRequest({
     query: GET_ALL_PROJECTS_QUERY,
     variables: { locale },

--- a/src/pages/projects/[slug].module.scss
+++ b/src/pages/projects/[slug].module.scss
@@ -50,10 +50,13 @@
 
 .descriptionContainer {
   @include flexCenter(column, space-around, stretch);
+  margin: 0 10%;
+  text-align: left;
 }
 
 .descriptionTitle {
   margin-bottom: 1.5rem;
+  text-align: center;
 }
 
 .description {

--- a/src/pages/projects/[slug].tsx
+++ b/src/pages/projects/[slug].tsx
@@ -13,7 +13,6 @@ import { websiteUrl } from "@/utilities/general"
 import { useRouter } from "next/router"
 import { gqlRequest } from "@/lib/datoCMS"
 import {
-  getProjectNameByLocale,
   getProjectDescriptionByLocale,
   GET_ALL_SLUGS_QUERY,
   GET_PROJECT_BY_SLUG_QUERY,
@@ -30,6 +29,7 @@ interface StaticPropTypes {
 
 interface ParamsTypes {
   params: { slug: string }
+  locale: Locale
 }
 
 const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {
@@ -59,9 +59,7 @@ const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {
           [styles.darkTheme]: darkTheme,
         })}
       >
-        <h1 className={styles.title}>
-          {getProjectNameByLocale(project, locale as Locale)}
-        </h1>
+        <h1 className={styles.title}>{project.name}</h1>
         <div className={styles.projectContainer}>
           <div className={styles.technologiesContainer}>
             <h2 className={styles.technologiesTitle}>{t("technologies")}</h2>
@@ -112,10 +110,10 @@ export const getStaticPaths = async ({ locales }: StaticPropTypes) => {
   }
 }
 
-export const getStaticProps = async ({ params }: ParamsTypes) => {
+export const getStaticProps = async ({ params, locale }: ParamsTypes) => {
   const data = await gqlRequest({
     query: GET_PROJECT_BY_SLUG_QUERY,
-    variables: { slug: params.slug },
+    variables: { slug: params.slug, locale },
   })
 
   return {

--- a/src/pages/projects/[slug].tsx
+++ b/src/pages/projects/[slug].tsx
@@ -13,7 +13,7 @@ import { websiteUrl } from "@/utilities/general"
 import { useRouter } from "next/router"
 import { gqlRequest } from "@/lib/datoCMS"
 import {
-  GET_ALL_SLUGS_QUERY,
+  GET_ALL_PROJECTS_QUERY,
   GET_PROJECT_BY_SLUG_QUERY,
 } from "@/graphql/projects"
 import { StructuredText } from "react-datocms"
@@ -89,10 +89,10 @@ const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {
 // Runs during build time only & can only work with getStaticProps
 // Gets locales from context to generate multilanguage pages for each project
 export const getStaticPaths = async ({ locales }: StaticPropTypes) => {
-  const slugs = await gqlRequest({
-    query: GET_ALL_SLUGS_QUERY,
+  const data = await gqlRequest({
+    query: GET_ALL_PROJECTS_QUERY,
   })
-  const paths = slugs.allProjects
+  const paths = data.allProjects
     .map((project: { slug: string }) => {
       return locales.map(locale => ({
         params: { slug: project.slug },

--- a/src/pages/projects/[slug].tsx
+++ b/src/pages/projects/[slug].tsx
@@ -13,7 +13,6 @@ import { websiteUrl } from "@/utilities/general"
 import { useRouter } from "next/router"
 import { gqlRequest } from "@/lib/datoCMS"
 import {
-  getProjectDescriptionByLocale,
   GET_ALL_SLUGS_QUERY,
   GET_PROJECT_BY_SLUG_QUERY,
 } from "@/graphql/projects"
@@ -79,9 +78,7 @@ const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {
           <div className={styles.descriptionContainer}>
             <h2 className={styles.descriptionTitle}> {t("description")}</h2>
 
-            <StructuredText
-              data={getProjectDescriptionByLocale(project, locale as Locale)}
-            />
+            <StructuredText data={project.description} />
           </div>
         </div>
       </section>


### PR DESCRIPTION
- [x] Pass `locale` argument to `GraphQL` queries instead of stupidly filtering data by locale through javascript;
- [x] Ensure that everything is localised (SEO and images' `alt`);
- [x] Adjust UI.