### PR TITLE
12 - Add DatoCMS preview mode

### DIFF
--- a/src/components/Projects/Card.tsx
+++ b/src/components/Projects/Card.tsx
@@ -18,43 +18,47 @@ interface PropTypes {
 const Card = ({ name, img, url, repo, slug }: PropTypes) => {
   const { darkTheme } = useContext(ThemeContext)
   const { t } = useTranslation("project")
+  const contentExists = img && name && slug
 
   return (
-    <li className={cn(styles.card, { [styles.darkTheme]: darkTheme })}>
-      <Link href={`/projects/${slug}`} passHref>
-        <a className={styles.imageContainer} title={name}>
-          <Image data={img.responsiveImage} />
-        </a>
-      </Link>
-      <h3 className={styles.projectName}>{name}</h3>
+    contentExists && (
+      <li className={cn(styles.card, { [styles.darkTheme]: darkTheme })}>
+        <Link href={`/projects/${slug}`} passHref>
+          <a className={styles.imageContainer} title={name}>
+            <Image data={img.responsiveImage} />
+          </a>
+        </Link>
 
-      <Link href={`/projects/${slug}`} passHref>
-        <a className={styles.projectDetails} title={name}>
-          {t("moreDetails")}
-        </a>
-      </Link>
+        <h3 className={styles.projectName}>{name}</h3>
 
-      <div className={styles.cardFooter}>
-        {url && (
-          <div className={styles.projectLink}>
-            <Link href={url} passHref>
-              <a title={url}>
-                <i className="fas fa-link"></i>
-              </a>
-            </Link>
-          </div>
-        )}
-        {repo && (
-          <div className={styles.projectRepo}>
-            <Link href={repo} passHref>
-              <a title={repo}>
-                <i className="fab fa-github"></i>
-              </a>
-            </Link>
-          </div>
-        )}
-      </div>
-    </li>
+        <Link href={`/projects/${slug}`} passHref>
+          <a className={styles.projectDetails} title={name}>
+            {t("moreDetails")}
+          </a>
+        </Link>
+
+        <div className={styles.cardFooter}>
+          {url && (
+            <div className={styles.projectLink}>
+              <Link href={url} passHref>
+                <a title={url}>
+                  <i className="fas fa-link"></i>
+                </a>
+              </Link>
+            </div>
+          )}
+          {repo && (
+            <div className={styles.projectRepo}>
+              <Link href={repo} passHref>
+                <a title={repo}>
+                  <i className="fab fa-github"></i>
+                </a>
+              </Link>
+            </div>
+          )}
+        </div>
+      </li>
+    )
   )
 }
 

--- a/src/components/Projects/Card.tsx
+++ b/src/components/Projects/Card.tsx
@@ -21,44 +21,46 @@ const Card = ({ name, img, url, repo, slug }: PropTypes) => {
   const contentExists = img && name && slug
 
   return (
-    contentExists && (
-      <li className={cn(styles.card, { [styles.darkTheme]: darkTheme })}>
-        <Link href={`/projects/${slug}`} passHref>
-          <a className={styles.imageContainer} title={name}>
-            <Image data={img.responsiveImage} />
-          </a>
-        </Link>
+    <>
+      {contentExists && (
+        <li className={cn(styles.card, { [styles.darkTheme]: darkTheme })}>
+          <Link href={`/projects/${slug}`} passHref>
+            <a className={styles.imageContainer} title={name}>
+              <Image data={img.responsiveImage} />
+            </a>
+          </Link>
 
-        <h3 className={styles.projectName}>{name}</h3>
+          <h3 className={styles.projectName}>{name}</h3>
 
-        <Link href={`/projects/${slug}`} passHref>
-          <a className={styles.projectDetails} title={name}>
-            {t("moreDetails")}
-          </a>
-        </Link>
+          <Link href={`/projects/${slug}`} passHref>
+            <a className={styles.projectDetails} title={name}>
+              {t("moreDetails")}
+            </a>
+          </Link>
 
-        <div className={styles.cardFooter}>
-          {url && (
-            <div className={styles.projectLink}>
-              <Link href={url} passHref>
-                <a title={url}>
-                  <i className="fas fa-link"></i>
-                </a>
-              </Link>
-            </div>
-          )}
-          {repo && (
-            <div className={styles.projectRepo}>
-              <Link href={repo} passHref>
-                <a title={repo}>
-                  <i className="fab fa-github"></i>
-                </a>
-              </Link>
-            </div>
-          )}
-        </div>
-      </li>
-    )
+          <div className={styles.cardFooter}>
+            {url && (
+              <div className={styles.projectLink}>
+                <Link href={url} passHref>
+                  <a title={url}>
+                    <i className="fas fa-link"></i>
+                  </a>
+                </Link>
+              </div>
+            )}
+            {repo && (
+              <div className={styles.projectRepo}>
+                <Link href={repo} passHref>
+                  <a title={repo}>
+                    <i className="fab fa-github"></i>
+                  </a>
+                </Link>
+              </div>
+            )}
+          </div>
+        </li>
+      )}
+    </>
   )
 }
 

--- a/src/components/Projects/Card.tsx
+++ b/src/components/Projects/Card.tsx
@@ -18,7 +18,7 @@ interface PropTypes {
 const Card = ({ name, img, url, repo, slug }: PropTypes) => {
   const { darkTheme } = useContext(ThemeContext)
   const { t } = useTranslation("project")
-  const contentExists = img && name && slug
+  const contentExists = img && name && slug && (url || repo)
 
   return (
     <>

--- a/src/pages/api/end-preview.ts
+++ b/src/pages/api/end-preview.ts
@@ -1,0 +1,6 @@
+import { NextApiRequest, NextApiResponse } from "next"
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.clearPreviewData() // Clears browser's cookies to disable preview mode.
+  res.end("Preview mode disabled")
+}

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -1,0 +1,8 @@
+import { NextApiRequest, NextApiResponse } from "next"
+
+// Endpoint to allow preview of a draft from the used headless CMS. The preview is rendered at request time instead of build time
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setPreviewData({})
+  res.writeHead(307, { Location: "/" })
+  res.end()
+}

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next"
 
-// Endpoint to allow preview of a draft from the used headless CMS. The preview is rendered at request time instead of build time
+// Endpoint to enable preview mode. Useful to preview a headless CMS draft. The preview is rendered at request time instead of build time
+// The preview mode will remain enabled unless another endpoint to disable it is called
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   res.setPreviewData({}) // Sets browser's cookie to allow preview mode. Any request containing this cookie will be rendered in preview mode
   res.writeHead(307, { Location: "/" })

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -1,9 +1,17 @@
+import { APIResponse } from "@/types/api"
 import { NextApiRequest, NextApiResponse } from "next"
 
 // Endpoint to enable preview mode. Useful to preview a headless CMS draft. The preview is rendered at request time instead of build time
 // The preview mode will remain enabled unless another endpoint to disable it is called
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.setPreviewData({}) // Sets browser's cookie to allow preview mode. Any request containing this cookie will be rendered in preview mode
-  res.writeHead(307, { Location: "/" })
-  res.end()
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<APIResponse>
+) {
+  res.setPreviewData({}) // Sets browser's cookie to enable preview mode. Any request containing this cookie will be rendered in preview mode
+  if (req.query.secret !== process.env.NEXT_DATOCMS_DRAFT_TOKEN) {
+    // Token is used to restrict access to CMS's draft. This should only be known to this API route and the CMS
+    return res.status(401).json({ status: "error", msg: "Invalid token" })
+  }
+
+  res.end("Preview mode enabled")
 }

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next"
 
 // Endpoint to allow preview of a draft from the used headless CMS. The preview is rendered at request time instead of build time
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.setPreviewData({})
+  res.setPreviewData({}) // Sets browser's cookie to allow preview mode. Any request containing this cookie will be rendered in preview mode
   res.writeHead(307, { Location: "/" })
   res.end()
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,7 @@ const HomePage: NextPage<PropTypes> = ({ data }: PropTypes) => {
       <SEO
         title={t("title")}
         description={t("description")}
-        keywords="Yacine Hadj Rabia, portfolio, ReactJS, NodeJS, NextJS, TypeScript, JavaScript, Sass"
+        keywords="YHR, Yacine Hadj Rabia, portfolio, ReactJS, NodeJS, NextJS, TypeScript, JavaScript, Sass"
         ogTitle={t("title")}
         ogDescription={t("description")}
       >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,15 +15,10 @@ import Hero from "@/components/Hero/Hero"
 import { GET_ALL_PROJECTS_QUERY } from "@/graphql/projects"
 import { gqlRequest } from "@/lib/datoCMS"
 import { Project } from "@/types/models/projects"
-import { Locale } from "@/types/locales"
+import { ContextProps } from "@/types/context"
 
 interface PropTypes {
   data: { allProjects: Project[] }
-}
-
-interface StaticPropTypes {
-  locale: Locale
-  preview: boolean
 }
 
 const HomePage: NextPage<PropTypes> = ({ data }: PropTypes) => {
@@ -78,7 +73,7 @@ const HomePage: NextPage<PropTypes> = ({ data }: PropTypes) => {
   )
 }
 
-export const getStaticProps = async ({ locale, preview }: StaticPropTypes) => {
+export const getStaticProps = async ({ locale, preview }: ContextProps) => {
   const data = await gqlRequest({
     query: GET_ALL_PROJECTS_QUERY,
     variables: { locale },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,6 +23,7 @@ interface PropTypes {
 
 interface StaticPropTypes {
   locale: Locale
+  preview: boolean
 }
 
 const HomePage: NextPage<PropTypes> = ({ data }: PropTypes) => {
@@ -77,10 +78,11 @@ const HomePage: NextPage<PropTypes> = ({ data }: PropTypes) => {
   )
 }
 
-export const getStaticProps = async ({ locale }: StaticPropTypes) => {
+export const getStaticProps = async ({ locale, preview }: StaticPropTypes) => {
   const data = await gqlRequest({
     query: GET_ALL_PROJECTS_QUERY,
     variables: { locale },
+    includeDrafts: preview,
   })
   return {
     props: { data },

--- a/src/pages/projects/[slug].tsx
+++ b/src/pages/projects/[slug].tsx
@@ -18,6 +18,7 @@ import {
 } from "@/graphql/projects"
 import { StructuredText } from "react-datocms"
 import { generateLocalisedPaths } from "@/utilities/locales"
+import { ContextProps } from "@/types/context"
 
 interface PropTypes {
   project: Project
@@ -27,10 +28,8 @@ interface StaticPropTypes {
   locales: Locale[]
 }
 
-interface ParamsTypes {
+interface ParamsTypes extends ContextProps {
   params: { slug: string }
-  locale: Locale
-  preview: boolean
 }
 
 const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {

--- a/src/pages/projects/[slug].tsx
+++ b/src/pages/projects/[slug].tsx
@@ -43,6 +43,8 @@ const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {
 
   const icons = skills.map(skill => getIconBySlug(skill)?.icon ?? "")
 
+  const hasName = project.name.length
+
   return (
     <>
       <SEO
@@ -60,7 +62,7 @@ const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {
           [styles.darkTheme]: darkTheme,
         })}
       >
-        <h1 className={styles.title}>{project.name}</h1>
+        {hasName && <h1 className={styles.title}>{project.name}</h1>}
         <div className={styles.projectContainer}>
           <div className={styles.technologiesContainer}>
             <h2 className={styles.technologiesTitle}>{t("technologies")}</h2>

--- a/src/pages/projects/[slug].tsx
+++ b/src/pages/projects/[slug].tsx
@@ -30,6 +30,7 @@ interface StaticPropTypes {
 interface ParamsTypes {
   params: { slug: string }
   locale: Locale
+  preview: boolean
 }
 
 const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {
@@ -101,10 +102,15 @@ export const getStaticPaths = async ({ locales }: StaticPropTypes) => {
   }
 }
 
-export const getStaticProps = async ({ params, locale }: ParamsTypes) => {
+export const getStaticProps = async ({
+  params,
+  locale,
+  preview,
+}: ParamsTypes) => {
   const data = await gqlRequest({
     query: GET_PROJECT_BY_SLUG_QUERY,
     variables: { slug: params.slug, locale },
+    includeDrafts: preview,
   })
 
   return {

--- a/src/pages/projects/[slug].tsx
+++ b/src/pages/projects/[slug].tsx
@@ -78,7 +78,7 @@ const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {
             </div>
           </div>
           <div className={styles.descriptionContainer}>
-            <h2 className={styles.descriptionTitle}> {t("description")}</h2>
+            <h2 className={styles.descriptionTitle}>{t("description")}</h2>
 
             <StructuredText data={project.description} />
           </div>

--- a/src/pages/projects/[slug].tsx
+++ b/src/pages/projects/[slug].tsx
@@ -26,6 +26,7 @@ interface PropTypes {
 
 interface StaticPropTypes {
   locales: Locale[]
+  preview: boolean
 }
 
 interface ParamsTypes extends ContextProps {
@@ -89,9 +90,10 @@ const ProjectPage: NextPage<PropTypes> = ({ project }: PropTypes) => {
 
 // Runs during build time only & can only work with getStaticProps
 // Gets locales from context to generate multilanguage pages for each project
-export const getStaticPaths = async ({ locales }: StaticPropTypes) => {
+export const getStaticPaths = async ({ locales, preview }: StaticPropTypes) => {
   const data = await gqlRequest({
     query: GET_ALL_PROJECTS_QUERY,
+    includeDrafts: preview,
   })
   const paths = generateLocalisedPaths(data.allProjects, locales)
 

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,0 +1,6 @@
+import { Locale } from "./locales"
+
+export type ContextProps = {
+  locale: Locale
+  preview: boolean
+}


### PR DESCRIPTION
Grants user the ability to preview draft content without needing to publish it on the headless CMS.

- [x] Add `/api/preview?secret=#########` endpoint to enable preview mode;
- [x] Add `/api/end-preview` endpoint to disable preview mode;
- [x] Refactor code;
- [x] Conditionally render elements based on available data (could typically induce bugs if not all fields of CMS entry are input);
- [x] Set up preview mode on homepage and projects pages.