### PR TITLE
Fix - Optimise preview mode

### DIFF
--- a/src/pages/api/end-preview.ts
+++ b/src/pages/api/end-preview.ts
@@ -1,6 +1,0 @@
-import { NextApiResponse } from "next"
-
-export default function handler(res: NextApiResponse) {
-  res.clearPreviewData() // Clears browser's cookies to disable preview mode.
-  res.end("Preview mode disabled")
-}

--- a/src/pages/api/end-preview.ts
+++ b/src/pages/api/end-preview.ts
@@ -1,6 +1,6 @@
-import { NextApiRequest, NextApiResponse } from "next"
+import { NextApiResponse } from "next"
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default function handler(res: NextApiResponse) {
   res.clearPreviewData() // Clears browser's cookies to disable preview mode.
   res.end("Preview mode disabled")
 }

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -2,7 +2,7 @@ import { APIResponse } from "@/types/api"
 import { NextApiRequest, NextApiResponse } from "next"
 
 // Endpoint to enable/disable preview mode. Useful to preview a headless CMS draft. The preview is rendered at request time instead of build time
-// The preview mode will remain enabled unless called with a `?disable=true` query parameter
+// The preview mode will remain enabled unless the endpoint is called with a `?disable=(anything-here)` query parameter
 export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<APIResponse>

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -12,7 +12,7 @@ export default function handler(
   // Disable mode
   if (disable === "true" && !secret) {
     res.clearPreviewData() // Clears browser's cookies to disable preview mode.
-    res.end("Preview mode disabled")
+    return res.end("Preview mode disabled")
   }
 
   // Enable mode

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -1,13 +1,13 @@
 import { APIResponse } from "@/types/api"
 import { NextApiRequest, NextApiResponse } from "next"
 
-// Endpoint to enable preview mode. Useful to preview a headless CMS draft. The preview is rendered at request time instead of build time
-// The preview mode will remain enabled unless another endpoint to disable it is called
+// Endpoint to enable/disable preview mode. Useful to preview a headless CMS draft. The preview is rendered at request time instead of build time
+// The preview mode will remain enabled unless called with a `?disable=true` query parameter
 export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<APIResponse>
 ) {
-  if (req.query.mode === "disable") {
+  if (req.query.disable === "true") {
     res.clearPreviewData() // Clears browser's cookies to disable preview mode.
     res.end("Preview mode disabled")
   }

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -7,7 +7,7 @@ export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<APIResponse>
 ) {
-  if (req.query.disable === "true") {
+  if (req.query.disable) {
     res.clearPreviewData() // Clears browser's cookies to disable preview mode.
     res.end("Preview mode disabled")
   }

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -12,6 +12,5 @@ export default function handler(
     return res.status(401).json({ status: "error", msg: "Invalid token" })
   }
   res.setPreviewData({}) // Sets browser's cookie to enable preview mode. Any request containing this cookie will be rendered in preview mode
-
   res.end("Preview mode enabled")
 }

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -2,19 +2,21 @@ import { APIResponse } from "@/types/api"
 import { NextApiRequest, NextApiResponse } from "next"
 
 // Endpoint to enable/disable preview mode. Useful to preview a headless CMS draft. The preview is rendered at request time instead of build time
-// The preview mode will remain enabled unless the endpoint is called with a `?disable=(anything-here)` query parameter
+// The preview mode will remain enabled unless the endpoint is called with a `?disable=true` query parameter
 export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<APIResponse>
 ) {
+  const { disable, secret } = req.query
+
   // Disable mode
-  if (req.query.disable) {
+  if (disable === "true" && !secret) {
     res.clearPreviewData() // Clears browser's cookies to disable preview mode.
     res.end("Preview mode disabled")
   }
 
   // Enable mode
-  if (req.query.secret !== process.env.NEXT_DATOCMS_DRAFT_TOKEN) {
+  if (secret !== process.env.NEXT_DATOCMS_DRAFT_TOKEN) {
     // Token is used to restrict access to CMS's draft. This should only be known to this API route and the CMS
     return res.status(401).json({ status: "error", msg: "Invalid token" })
   }

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -7,6 +7,10 @@ export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<APIResponse>
 ) {
+  if (req.query.mode === "disable") {
+    res.clearPreviewData() // Clears browser's cookies to disable preview mode.
+    res.end("Preview mode disabled")
+  }
   if (req.query.secret !== process.env.NEXT_DATOCMS_DRAFT_TOKEN) {
     // Token is used to restrict access to CMS's draft. This should only be known to this API route and the CMS
     return res.status(401).json({ status: "error", msg: "Invalid token" })

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -7,10 +7,13 @@ export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<APIResponse>
 ) {
+  // Disable mode
   if (req.query.disable) {
     res.clearPreviewData() // Clears browser's cookies to disable preview mode.
     res.end("Preview mode disabled")
   }
+
+  // Enable mode
   if (req.query.secret !== process.env.NEXT_DATOCMS_DRAFT_TOKEN) {
     // Token is used to restrict access to CMS's draft. This should only be known to this API route and the CMS
     return res.status(401).json({ status: "error", msg: "Invalid token" })

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -7,11 +7,11 @@ export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<APIResponse>
 ) {
-  res.setPreviewData({}) // Sets browser's cookie to enable preview mode. Any request containing this cookie will be rendered in preview mode
   if (req.query.secret !== process.env.NEXT_DATOCMS_DRAFT_TOKEN) {
     // Token is used to restrict access to CMS's draft. This should only be known to this API route and the CMS
     return res.status(401).json({ status: "error", msg: "Invalid token" })
   }
+  res.setPreviewData({}) // Sets browser's cookie to enable preview mode. Any request containing this cookie will be rendered in preview mode
 
   res.end("Preview mode enabled")
 }


### PR DESCRIPTION
Remove redundancy by using single `/api/preview` endpoint to both `enable` and `disable` draft mode.

- [x] Remove `end-preview` endpoint;
- [x] Make `preview` endpoint more secure;
- [x] Add `disable` query param to endpoint — any given value would disable draft mode.

## ℹ️  How to proceed:

### Enable preview mode:
Call `/api/preview?secret=(SECRET-TOKEN)`

### Disable preview mode:
Call `/api/preview?disable=true`